### PR TITLE
Ajustes no dono da lista e nos colaboradores.

### DIFF
--- a/Superlista.xcodeproj/project.pbxproj
+++ b/Superlista.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		09725B1F264C63510006D410 /* ListPerItemsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09725B1E264C63510006D410 /* ListPerItemsView.swift */; };
 		09725B232652DCAD0006D410 /* ListByCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09725B222652DCAD0006D410 /* ListByCategoryView.swift */; };
 		09725B2F2656E0000006D410 /* DefaultLS.png in Resources */ = {isa = PBXBuildFile; fileRef = 09725B2E2656E0000006D410 /* DefaultLS.png */; };
+		0977040E2728C62500232F9D /* CKOwnerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0977040D2728C62400232F9D /* CKOwnerModel.swift */; };
+		097704102728C63800232F9D /* OwnerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0977040F2728C63800232F9D /* OwnerModel.swift */; };
+		097704122728C80800232F9D /* OwnerModelConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097704112728C80800232F9D /* OwnerModelConverter.swift */; };
 		09BE3B9E265C228900F5E7C5 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09BE3B9D265C228900F5E7C5 /* SplashView.swift */; };
 		1B325E2126545176001A0F28 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1B325E2026545176001A0F28 /* LaunchScreen.storyboard */; };
 		1B32EF0A26600A41006AE70B /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 1B32EF0926600A41006AE70B /* Lottie */; };
@@ -46,7 +49,6 @@
 		1BFA60572641DB770030AE03 /* ProductModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BFA60562641DB770030AE03 /* ProductModel.swift */; };
 		1BFA60682641DE9B0030AE03 /* productList.json in Resources */ = {isa = PBXBuildFile; fileRef = 1BFA60672641DE9B0030AE03 /* productList.json */; };
 		382E7F5627189A9500EE4E5D /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382E7F5527189A9500EE4E5D /* NetworkMonitor.swift */; };
-		890913822649BC8100C619A3 /* DataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 890913812649BC8100C619A3 /* DataService.swift */; };
 		382E7F5A271DEF4600EE4E5D /* UserArrays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382E7F59271DEF4600EE4E5D /* UserArrays.swift */; };
 		382E7F66271E0EA600EE4E5D /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 382E7F68271E0EA600EE4E5D /* Localizable.strings */; };
 		389B80CC271F5D2C00ADCBE1 /* Wave.swift in Sources */ = {isa = PBXBuildFile; fileRef = 389B80CB271F5D2C00ADCBE1 /* Wave.swift */; };
@@ -57,6 +59,7 @@
 		389B80DB271F7E8200ADCBE1 /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 389B80DA271F7E8200ADCBE1 /* ProfileViewModel.swift */; };
 		389B80DD271F848300ADCBE1 /* ProfileHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 389B80DC271F848300ADCBE1 /* ProfileHeader.swift */; };
 		389B80E02720AEFB00ADCBE1 /* EditProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 389B80DF2720AEFB00ADCBE1 /* EditProfileView.swift */; };
+		890913822649BC8100C619A3 /* DataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 890913812649BC8100C619A3 /* DataService.swift */; };
 		890913842649BCCA00C619A3 /* ListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 890913832649BCCA00C619A3 /* ListModel.swift */; };
 		893BA28A2654A84600A300DA /* CategoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 893BA2892654A84600A300DA /* CategoryModel.swift */; };
 		8948F8D4265325E000394EB6 /* ListHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8948F8D3265325E000394EB6 /* ListHeader.swift */; };
@@ -101,6 +104,9 @@
 		09725B1E264C63510006D410 /* ListPerItemsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListPerItemsView.swift; sourceTree = "<group>"; };
 		09725B222652DCAD0006D410 /* ListByCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListByCategoryView.swift; sourceTree = "<group>"; };
 		09725B2E2656E0000006D410 /* DefaultLS.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = DefaultLS.png; sourceTree = "<group>"; };
+		0977040D2728C62400232F9D /* CKOwnerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CKOwnerModel.swift; sourceTree = "<group>"; };
+		0977040F2728C63800232F9D /* OwnerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OwnerModel.swift; sourceTree = "<group>"; };
+		097704112728C80800232F9D /* OwnerModelConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OwnerModelConverter.swift; sourceTree = "<group>"; };
 		09BE3B9D265C228900F5E7C5 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		1B325E2026545176001A0F28 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		1B32EF0E26600AA1006AE70B /* NoItemsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoItemsView.swift; sourceTree = "<group>"; };
@@ -127,7 +133,6 @@
 		1BFA60562641DB770030AE03 /* ProductModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductModel.swift; sourceTree = "<group>"; };
 		1BFA60672641DE9B0030AE03 /* productList.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = productList.json; sourceTree = "<group>"; };
 		382E7F5527189A9500EE4E5D /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
-		890913812649BC8100C619A3 /* DataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataService.swift; sourceTree = "<group>"; };
 		382E7F59271DEF4600EE4E5D /* UserArrays.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserArrays.swift; sourceTree = "<group>"; };
 		382E7F67271E0EA600EE4E5D /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		382E7F69271E0EAA00EE4E5D /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -140,6 +145,7 @@
 		389B80DA271F7E8200ADCBE1 /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
 		389B80DC271F848300ADCBE1 /* ProfileHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileHeader.swift; sourceTree = "<group>"; };
 		389B80DF2720AEFB00ADCBE1 /* EditProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileView.swift; sourceTree = "<group>"; };
+		890913812649BC8100C619A3 /* DataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataService.swift; sourceTree = "<group>"; };
 		890913832649BCCA00C619A3 /* ListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListModel.swift; sourceTree = "<group>"; };
 		893BA2892654A84600A300DA /* CategoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryModel.swift; sourceTree = "<group>"; };
 		8948F8D3265325E000394EB6 /* ListHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListHeader.swift; sourceTree = "<group>"; };
@@ -194,6 +200,7 @@
 				0914B97D270B6CF8008E297F /* CKUserModel.swift */,
 				0914B981270B8016008E297F /* CKListModel.swift */,
 				0914B983270B84E8008E297F /* CKItemModel.swift */,
+				0977040D2728C62400232F9D /* CKOwnerModel.swift */,
 			);
 			path = CKModels;
 			sourceTree = "<group>";
@@ -207,6 +214,7 @@
 				890913832649BCCA00C619A3 /* ListModel.swift */,
 				893BA2892654A84600A300DA /* CategoryModel.swift */,
 				1B60EC892719E9F500046FE9 /* UserModel.swift */,
+				0977040F2728C63800232F9D /* OwnerModel.swift */,
 			);
 			path = LocalModels;
 			sourceTree = "<group>";
@@ -237,6 +245,7 @@
 				1B93E8F0270F901500AA89B6 /* ItemModelConverter.swift */,
 				1B60EC8B2719EB6000046FE9 /* UserModelConverter.swift */,
 				1B60EC8D271A020300046FE9 /* ProductModelConverter.swift */,
+				097704112728C80800232F9D /* OwnerModelConverter.swift */,
 			);
 			path = BridgeModels;
 			sourceTree = "<group>";
@@ -522,6 +531,7 @@
 				09BE3B9E265C228900F5E7C5 /* SplashView.swift in Sources */,
 				389B80D3271F7C5700ADCBE1 /* ProfilePicture.swift in Sources */,
 				8980E9CA2644AF91002A5073 /* ListView.swift in Sources */,
+				0977040E2728C62500232F9D /* CKOwnerModel.swift in Sources */,
 				1B93E8F1270F901500AA89B6 /* ItemModelConverter.swift in Sources */,
 				1B43E5AE264B0F61002C6D64 /* MainView.swift in Sources */,
 				389B80D7271F7DB300ADCBE1 /* ImagePicker.swift in Sources */,
@@ -533,6 +543,7 @@
 				09725B1F264C63510006D410 /* ListPerItemsView.swift in Sources */,
 				893BA28A2654A84600A300DA /* CategoryModel.swift in Sources */,
 				09725B232652DCAD0006D410 /* ListByCategoryView.swift in Sources */,
+				097704102728C63800232F9D /* OwnerModel.swift in Sources */,
 				0914B984270B84E8008E297F /* CKItemModel.swift in Sources */,
 				1B60EC8A2719E9F500046FE9 /* UserModel.swift in Sources */,
 				389B80CC271F5D2C00ADCBE1 /* Wave.swift in Sources */,
@@ -551,6 +562,7 @@
 				0914B982270B8016008E297F /* CKListModel.swift in Sources */,
 				898D645B264316300019ABCE /* ProductListViewModel.swift in Sources */,
 				1BE5B6E4270E126A00338A02 /* ListModelConverter.swift in Sources */,
+				097704122728C80800232F9D /* OwnerModelConverter.swift in Sources */,
 				09725B1D264C60BC0006D410 /* ItemCommentView.swift in Sources */,
 				389B80E02720AEFB00ADCBE1 /* EditProfileView.swift in Sources */,
 				0914B97E270B6CF8008E297F /* CKUserModel.swift in Sources */,

--- a/Superlista/Models/BridgeModels/ListModelConverter.swift
+++ b/Superlista/Models/BridgeModels/ListModelConverter.swift
@@ -81,14 +81,14 @@ class ListModelConverter {
         
         let localItems = itemModelConverter.convertCloudItemsToLocal(withItems: list.itemsModel)
        
-      //  let localOwner = UserModelConverter().convertCloudOwnerToLocal(withUser: list.owner)
+        let localOwner = OwnerModelConverter().convertCKOwnerToLocal(withUser: list.owner!)
         
-        var localSharedWith: [UserModel] = []
-//        for shared in list.sharedWith {
-//            localSharedWith.append(UserModelConverter().convertCloudOwnerToLocal(withUser: shared))
-//        }
+        var localSharedWith: [OwnerModel] = []
+        for shared in list.sharedWith {
+            localSharedWith.append(OwnerModelConverter().convertCKOwnerToLocal(withUser: shared))
+        }
         
-        localList = ListModel(id: list.id.recordName, title: list.name ?? "", items: localItems)
+        localList = ListModel(id: list.id.recordName, title: list.name ?? "", items: localItems, owner: localOwner, sharedWith: localSharedWith)
         
         
         return localList
@@ -110,18 +110,18 @@ class ListModelConverter {
         cloudList.name = list.title
         cloudList.itemsModel = itemModelConverter.convertLocalItemsToCloudItems(withItemsList: list.items)
         cloudList.itemsString = itemModelConverter.parseCKItemObjectToString(withItems: cloudList.itemsModel)
-      //  cloudList.owner = UserModelConverter().convertLocalUserToCloud(withUser: list.owner)
+        cloudList.owner = OwnerModelConverter().convertLocalToCKOwner(withUser: list.owner)
         
-        var cloudSharedWith: [CKUserModel] = []
-//        for shared in list.sharedWith ?? []  {
-//            cloudSharedWith.append(UserModelConverter().convertLocalUserToCloud(withUser: shared))
-//        }
+        var cloudSharedWith: [CKOwnerModel] = []
+        for shared in list.sharedWith ?? []  {
+            cloudSharedWith.append(OwnerModelConverter().convertLocalToCKOwner(withUser: shared))
+        }
         cloudList.sharedWith = cloudSharedWith
         
         var cloudSharedWithRef: [CKRecord.Reference] = []
-//        for shared in cloudSharedWith {
-//            cloudSharedWithRef.append(UserModelConverter().convertCloudUserToReference(withUser: shared))
-//        }
+        for shared in cloudSharedWith {
+            cloudSharedWithRef.append(CKRecord.Reference(recordID: shared.id, action: .none))
+        }
         cloudList.sharedWithRef = cloudSharedWithRef
         
         return cloudList

--- a/Superlista/Models/BridgeModels/OwnerModelConverter.swift
+++ b/Superlista/Models/BridgeModels/OwnerModelConverter.swift
@@ -1,0 +1,70 @@
+import Foundation
+import CloudKit
+
+//MARK: - OwnerModelConverter Class
+
+/**
+ OwnerModelConverter is a Bridge class converting our Cloud record/class of User arquitecture to our local/UserDefaults class arquitecture.
+ 
+ According to its formal definition, a Bridge is something that meakes its easier to change from one situation to another. In this case, instead of refactoring the whole backend everytime we make a new implementation of a service, a Bridge class connects both arquitectures by parsing each to each. This way is possible to manipulate both strcutures without backend refactoring.
+ */
+class OwnerModelConverter {
+    //MARK: OwnerModelConverter Functions: Reference to ☁️
+    
+    /**
+    This method converts the CKRecord.Reference structure to our cloud CKOwnerModel structure
+     
+     - Parameters:
+        - items: the reference to be converted
+     - Returns: the CKOwnerModel version of the given reference
+     */
+    func convertReferenceToCK(withReference reference: CKRecord.Reference, completion: @escaping (Result<CKOwnerModel, CKError>) -> Void) {
+        var owner: CKOwnerModel = CKOwnerModel()
+        
+        DispatchQueue.global().async {
+            
+            var ckError: CKError?
+
+            CKService.currentModel.getAnotherUser(userID: reference.recordID) { result in
+                switch result {
+                case .success(let user):
+                    owner = user
+                case .failure(let error):
+                    ckError = error
+                }
+            }
+            if let error = ckError {
+                completion(.failure(error))
+
+            } else {
+                completion(.success(owner))
+            }
+        }
+    }
+    
+    //MARK: OwnerModelConverter Functions: ☁️ to Local
+    
+    /**
+    This method converts our current cloud CKOwnerModel structure to our local OwnerModel structure
+     
+     - Parameters:
+        - items: the CKOwnerModel to be converted
+     - Returns: the OwnerModel version of the given CKOwnerModel
+     */
+    func convertCKOwnerToLocal(withUser user: CKOwnerModel) -> OwnerModel {
+        return OwnerModel(id: user.id.recordName, name: user.name ?? "OwnerName")
+    }
+    
+    //MARK: OwnerModelConverter Functions: Local to ☁️
+    
+    /**
+    This method converts our current cloud OwnerModel structure to our local CKOwnerModel structure
+     
+     - Parameters:
+        - items: the OwnerModel to be converted
+     - Returns: the CKOwnerModel version of the given OwnerModel
+     */
+    func convertLocalToCKOwner(withUser user: OwnerModel) -> CKOwnerModel {
+        return CKOwnerModel(id: CKRecord.ID(recordName: user.id), name: user.name ?? "OwnerName") 
+    }
+}

--- a/Superlista/Models/CKModels/CKOwnerModel.swift
+++ b/Superlista/Models/CKModels/CKOwnerModel.swift
@@ -1,0 +1,34 @@
+import Foundation
+import CloudKit
+import SwiftUI
+
+//MARK: - Owner Model Class
+
+/**
+    Modelo de usuário do CloudKit para ser usado no owner de uma lista e no sharedWith das listas.
+ */
+class CKOwnerModel {
+    
+    //MARK: CKOwnerModel Variables
+    
+    var id: CKRecord.ID
+    var name: String?
+    var ckImage: CKAsset?
+    var image: UIImage?
+    
+    init(record: CKRecord) {
+        id = record.recordID
+        name = record["UserName"] as? String
+        ckImage = record["Image"] as? CKAsset
+        image = CKAssetToUIImage(ckImage: ckImage)
+    }
+    
+    init() {
+        id = CKRecord.ID()
+    }
+    
+    init(id: CKRecord.ID, name: String) {
+        self.id = id
+        self.name = name
+    }
+}

--- a/Superlista/Models/LocalModels/ListModel.swift
+++ b/Superlista/Models/LocalModels/ListModel.swift
@@ -6,27 +6,27 @@ struct ListModel: Identifiable, Decodable, Encodable {
     var title: String
     var items: [CategoryModel: [ItemModel]]
     
-    var owner: UserModel?
-    var sharedWith: [UserModel]?
+    var owner: OwnerModel
+    var sharedWith: [OwnerModel]?
     
-    init(title: String, items: [CategoryModel: [ItemModel]] = [:], sharedWith: [UserModel] = []) {
+    init(title: String, items: [CategoryModel: [ItemModel]] = [:], owner: OwnerModel, sharedWith: [OwnerModel] = []) {
         let recordID = CKRecord.ID()
         
         self.id = recordID.recordName
         self.title = title
         self.items = items
-//        self.owner = owner
+        self.owner = owner
     }
     
-    init(id: String, title: String, items: [CategoryModel: [ItemModel]] = [:], sharedWith: [UserModel] = []) {
+    init(id: String, title: String, items: [CategoryModel: [ItemModel]] = [:], owner: OwnerModel, sharedWith: [OwnerModel] = []) {
         self.id = id
         self.title = title
         self.items = items
- //       self.owner = owner
+        self.owner = owner
     }
     
     func editTitle(newTitle: String) -> ListModel {
-        return ListModel(id: id, title: newTitle, items: items)
+        return ListModel(id: id, title: newTitle, items: items, owner: owner)
     }
     
     func addItem(_ item: ItemModel) -> ListModel {
@@ -38,7 +38,7 @@ struct ListModel: Identifiable, Decodable, Encodable {
             newItemsList[CategoryModel(title: item.product.category)] = [item]
         }
         
-        return ListModel(id: id, title: title, items: newItemsList)
+        return ListModel(id: id, title: title, items: newItemsList, owner: owner)
     }
     
     func removeItem(from row: IndexSet, of category: CategoryModel) -> ListModel {
@@ -54,7 +54,7 @@ struct ListModel: Identifiable, Decodable, Encodable {
             
         }
         
-        return ListModel(id: id, title: title, items: newItemsList)
+        return ListModel(id: id, title: title, items: newItemsList, owner: owner)
     }
     
     func removeItem(_ item: ItemModel) -> ListModel {
@@ -71,7 +71,7 @@ struct ListModel: Identifiable, Decodable, Encodable {
             }
         }
         
-        return ListModel(id: id, title: title, items: newItemsList)
+        return ListModel(id: id, title: title, items: newItemsList, owner: owner)
     }
     
     func addComment(_ comment: String, to item: ItemModel) -> ListModel {
@@ -83,7 +83,7 @@ struct ListModel: Identifiable, Decodable, Encodable {
             newItemsList[category.key]?[itemIndex] = newItem.editComment(newComment: comment)
         }
         
-        return ListModel(id: id, title: title, items: newItemsList)
+        return ListModel(id: id, title: title, items: newItemsList, owner: owner)
     }
     
     func toggleCompletion(of item: ItemModel) -> ListModel {
@@ -95,6 +95,6 @@ struct ListModel: Identifiable, Decodable, Encodable {
             newItemsList[category.key]?[itemIndex] = newItem.toggleCompletion()
         }
         
-        return ListModel(id: id, title: title, items: newItemsList)
+        return ListModel(id: id, title: title, items: newItemsList, owner: owner)
     }
 }

--- a/Superlista/Models/LocalModels/OwnerModel.swift
+++ b/Superlista/Models/LocalModels/OwnerModel.swift
@@ -1,0 +1,21 @@
+import Foundation
+import CloudKit
+import SwiftUI
+
+//MARK: - Owner Model Class
+
+/**
+    Modelo de usuário local para ser usado no owner de uma lista e no sharedWith das listas.
+ */
+class OwnerModel: Encodable, Decodable {
+    
+    //MARK: OwnerModel Variables
+    
+    var id: String
+    var name: String?
+    
+    init(id: String, name: String) {
+        self.id = id
+        self.name = name
+    }
+}

--- a/Superlista/Models/LocalModels/UserModel.swift
+++ b/Superlista/Models/LocalModels/UserModel.swift
@@ -10,7 +10,7 @@ class UserModel: Identifiable, Decodable, Encodable {
     var myLists: [ListModel]?
     var sharedWithMe: [ListModel]?
     
-    #warning("Substituir a string fazia pelo nome aleatorio")
+    #warning("Substituir a string vazia pelo nome aleatorio")
     init(id: String, name: String? = "", customProducts: [ProductModel]? = [], myLists: [ListModel]? = [], sharedWithMe: [ListModel]? = []) {
         
         self.id = id

--- a/Superlista/Service/CKService.swift
+++ b/Superlista/Service/CKService.swift
@@ -134,18 +134,18 @@ class CKService: ObservableObject {
     }
     
 //    // MARK: - Get another user name
-//    func getAnotherUserName(userID: CKRecord.ID, completion: @escaping (Result<String,CKError>) -> Void) {
-//        publicDB.fetch(withRecordID: userID) { record, error in
-//            if error == nil {
-//                let user = CKUserModel(record: record!)
-//                completion(.success(user.name!))
-//                return
-//            } else {
-//                completion(.failure(error as! CKError))
-//                return
-//            }
-//        }
-//    }
+    func getAnotherUser(userID: CKRecord.ID, completion: @escaping (Result<CKOwnerModel,CKError>) -> Void) {
+        publicDB.fetch(withRecordID: userID) { record, error in
+            if error == nil {
+                let user = CKOwnerModel(record: record!)
+                completion(.success(user))
+                return
+            } else {
+                completion(.failure(error as! CKError))
+                return
+            }
+        }
+    }
     
     // MARK: - Update User Name
 #warning("Verificar se está sendo usado em algum lugar")

--- a/Superlista/Service/CustomSource.swift
+++ b/Superlista/Service/CustomSource.swift
@@ -4,18 +4,16 @@ import LinkPresentation
 class CustomSource: NSObject, UIActivityItemSource {
     let url: URL
     let listID: String
-    let ownerID: String
     let option: String
     let listName: String
     let ownerName: String
     
-    init(listID: String, ownerID: String, option: String, listName: String, ownerName: String) {
+    init(listID: String, option: String, listName: String, ownerName: String) {
         self.listID = listID
-        self.ownerID = ownerID
         self.option = option
         self.listName = listName
         self.ownerName = ownerName
-        self.url = URL(string: "easyrancho://" + ownerID + "$" + listID + "$" + option) ?? URL(string: "apple.com")!
+        self.url = URL(string: "easyrancho://" + listID + "$" + option) ?? URL(string: "apple.com")!
     }
     
     func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {

--- a/Superlista/Service/DeepLink.swift
+++ b/Superlista/Service/DeepLink.swift
@@ -3,14 +3,12 @@ import Foundation
 struct DeepLink {
     var id: String
     var listID: String?
-    var ownerID: String?
     var option: String?
     
     init(id: String) {
         self.id = id
         let ids = id.components(separatedBy: "$")
-        ownerID = ids[0]
-        listID = ids[1]
-        option = ids[2]
+        listID = ids[0]
+        option = ids[1]
     }
 }

--- a/Superlista/Service/Helper.swift
+++ b/Superlista/Service/Helper.swift
@@ -50,8 +50,8 @@ func CKAssetToUIImage(ckImage: CKAsset?) -> UIImage? {
 }
 
 // MARK: - ShareSheet
-func shareSheet(listID: String, ownerID: String, option: String, listName: String, ownerName: String) {
-    let activityVC = UIActivityViewController(activityItems: [CustomSource(listID: listID, ownerID: ownerID, option: option, listName: listName, ownerName: ownerName)], applicationActivities: nil)
+func shareSheet(listID: String, option: String, listName: String, ownerName: String) {
+    let activityVC = UIActivityViewController(activityItems: [CustomSource(listID: listID, option: option, listName: listName, ownerName: ownerName)], applicationActivities: nil)
     let keyWindow = UIApplication.shared.windows.first(where: \.isKeyWindow)
     var topController = keyWindow?.rootViewController
     

--- a/Superlista/SuperlistaApp.swift
+++ b/Superlista/SuperlistaApp.swift
@@ -29,9 +29,6 @@ struct SuperlistaApp: App {
                         handleDeepLink(deepLink)
                         
                     })
-                Button("Botao") {
-                    CKService.currentModel.updateListName(listName: "SOCORRO FUNCIONA", listID: CKRecord.ID(recordName: "466B6502-7066-4364-93D9-F6A248E0336E")) { result in }
-                }
                 }
             }
             .accentColor(Color("Link"))
@@ -52,7 +49,6 @@ struct SuperlistaApp: App {
     }
     
     func handleDeepLink(_ deeplink: DeepLink) {
-        guard let ownerID = deeplink.ownerID else { return }
         guard let listID = deeplink.listID else { return }
         guard let option = deeplink.option else { return }
         
@@ -71,7 +67,7 @@ struct SuperlistaApp: App {
                         print(result)
                     }
                 } else if option == "2" {
-                    let newListLocal = CKListModel(name: listName!, ownerRef: list.ownerRef, itemsString: list.itemsString, sharedWithRef: list.sharedWithRef)
+                    let newListLocal = CKListModel(name: listName!, ownerRef: list.ownerRef, itemsString: list.itemsString)
                     CKService.currentModel.createList(listModel: newListLocal) { result in
                         switch result {
                         case .success (let newListID):

--- a/Superlista/Views/MainView.swift
+++ b/Superlista/Views/MainView.swift
@@ -165,7 +165,8 @@ struct MainView: View {
     }
     
     func createNewListAction() {
-        let newList: ListModel = ListModel(title: "Nova Lista")
+        let newOwner: OwnerModel = OwnerModel(id: CKService.currentModel.user!.id.recordName, name:  CKService.currentModel.user!.name!)
+        let newList: ListModel = ListModel(title: "Nova Lista", owner: newOwner)
 
         dataService.addList(newList)
         self.listId = newList.id


### PR DESCRIPTION
Criação de uma classe chamada CKOwnerModel para os donos e colaboradores das listas quando o usuário estiver conectado ao CloudKit.
Criação de uma classe chamada OwnerModel para os donos e colaboradores das listas quando o usuário estiver local.
Criação da classe OwnerModelConverter para converter do padrão do CloudKit para o padrão local, além de transformar os dados que são recebidos do banco em forma de CKRecord.Reference em dados de CKOwnerModel.
Ajustes na classe de ListConverter para converter os donos e colaboradores no novo padrão.
Ajustes na ListModel e na CKListModel para receber os donos e colaboradores no novo padrão.
QUEBRA DO LOOPING! 🎊
CKService funcionando novamente 🎉